### PR TITLE
Re-add "cd" when running install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Run the installer
 -----------------
 Base installation:
 ```sh
-curl -OL https://raw.githubusercontent.com/cargomedia/osx-setup/master/install.sh && bash install.sh
+(cd $(mktemp -dti) && curl -OL https://raw.githubusercontent.com/cargomedia/osx-setup/master/install.sh && bash install.sh)
 ```
 
 Java


### PR DESCRIPTION
@mariansollmann ups, that wasn't good, as it would still download the file to the current directory..
pelase review