### PR TITLE
SSH roaming config problem

### DIFF
--- a/resource/osx/files/_default/_home/.ssh/config
+++ b/resource/osx/files/_default/_home/.ssh/config
@@ -2,4 +2,4 @@ ControlMaster auto
 ControlPath /tmp/ssh-%r@%h:%p
 ControlPersist 15m
 # This closes a security hole aka triple-seven (see https://www.qualys.com/2016/01/14/cve-2016-0777-cve-2016-0778/openssh-cve-2016-0777-cve-2016-0778.txt)
-UseRoaming No
+UseRoaming no


### PR DESCRIPTION
Followup to https://github.com/cargomedia/osx-setup/pull/111

```
/Users/reto/.ssh/config line 5: Bad yes/no argument.
```

@ppp0 can you check?