### PR TITLE
Some files changed their location in El Capitan

### DIFF
--- a/resource/osx/install/_default/scripts/osx.sh
+++ b/resource/osx/install/_default/scripts/osx.sh
@@ -69,7 +69,7 @@ if ! (test -e ~/.cargomedia-desktop); then
 	defaults write com.apple.Safari IncludeDebugMenu -bool true
 
 	# SSH
-	sudo perl -pi -e 's/^(\s*SendEnv LANG LC_\*)$/#$1/g' /etc/ssh_config
+	sudo perl -pi -e 's/^(\s*SendEnv LANG LC_\*)$/#$1/g' /etc/ssh/ssh_config
 
 	touch ~/.cargomedia-desktop
 	for app in Finder Dock SystemUIServer; do killall "$app"; done


### PR DESCRIPTION
I noticed that some of our ssh configuration doesn't work on El Capitan installation. Reason is some *system* files has been moved in new osx version. e.g.
- `/etc/ssh_config` has been moved to `/etc/ssh/ssh_config`.

Confirmation source:
https://maclemon.at/blog/2016/01/14/fixing-openssh-cve-2016-0777/
>  The path of ssh_config changed with OS X 10.11 (El Capitan). Thanks to @chrisridd for pointing me to it.

Possibly other files are influenced.