### PR TITLE
No available formula with the name "brew-cask"

### DIFF
--- a/library/Task/Sys/BrewCaskInstall.php
+++ b/library/Task/Sys/BrewCaskInstall.php
@@ -6,12 +6,6 @@ class Task_Sys_BrewCaskInstall extends Task {
         return 'Brew casks install';
     }
 
-    protected function _getDependencies() {
-        return array(
-            new Task_Sys_BrewInstall(array('brew-cask')),
-        );
-    }
-
     protected function _run() {
         $packages = array_merge($this->_getPackages('_default'), $this->_getPackages('%ROLE%'));
         $packages = array_unique($packages);


### PR DESCRIPTION
```bash
ERROR! Command failed: `/bin/bash -ec 'brew install brew-cask'`.                
Error: No available formula with the name "brew-cask" 
```

Turns out brew-cask is now into brew (for quite some time) so they removed the formula. See https://github.com/caskroom/homebrew-cask/commit/fb34c5c93f4641c91027b18a22c13381c9e68bfc.