### PR TITLE
Is it time to switch to php56?

### DIFF
--- a/resource/osx/install/_default/brew.list
+++ b/resource/osx/install/_default/brew.list
@@ -10,9 +10,9 @@ colordiff
 htop-osx
 iftop
 pstree
-php54 --with-mysql
-php54-apc
-php54-xdebug
+php56 --with-mysql
+php56-apcu
+php56-xdebug
 composer
 git
 bash-completion


### PR DESCRIPTION
@njam now that dev env is on Debian 8 should we upgrade to PHP 5.6 even on OSX?