### PR TITLE
Update softlayer routes

### DIFF
--- a/resource/osx/files/_default/etc/ppp/ip-up
+++ b/resource/osx/files/_default/etc/ppp/ip-up
@@ -1,12 +1,14 @@
 #!/bin/sh
 
-/sbin/route add 10.91.48.128/26 -interface $1
+# Softlayer DNS
+/sbin/route add 10.0.80.0/24 -interface $1
+
+# Softlayer subnets Cargo Media
 /sbin/route add 10.17.16.0/26 -interface $1
-/sbin/route add 10.55.40.128/16 -interface $1
-/sbin/route add 10.68.236.128/16 -interface $1
-/sbin/route add 10.91.26.128/16 -interface $1
-/sbin/route add 10.71.140.128/16 -interface $1
-/sbin/route add 10.0.80.0/16    -interface $1
+/sbin/route add 10.55.40.128/26 -interface $1
+/sbin/route add 10.68.236.64/26 -interface $1
+/sbin/route add 10.71.140.0/26 -interface $1
+/sbin/route add 10.91.48.128/26 -interface $1
 
 # This is needed for the native VPN (PPTP) client on osx to function with SoftLayer's VPN
 # It is routing the relevant private network requests to the vpn subnet over the ppp interface once it's enabled


### PR DESCRIPTION
I experienced some problems setting up the Softlayer VPN routes on Linux (routes were not accepted, because the gateway was on the "wrong" network or something like that).
Now I just added all networks exactly as they are defined in our Softlayer account:
https://control.bluemix.net/network/subnets

Works fine.

@ppp0 @kris-lab please review