### PR TITLE
Add php intl extension

### DIFF
--- a/resource/osx/files/_default/usr/local/etc/php/5.6/conf.d/ext-intl.ini
+++ b/resource/osx/files/_default/usr/local/etc/php/5.6/conf.d/ext-intl.ini
@@ -1,0 +1,1 @@
+extension=/usr/local/opt/php56-intl/intl.so

--- a/resource/osx/install/_default/brew.list
+++ b/resource/osx/install/_default/brew.list
@@ -13,6 +13,7 @@ pstree
 php56 --with-mysql
 php56-apcu
 php56-xdebug
+php56-intl
 composer
 git
 bash-completion


### PR DESCRIPTION
Some dependencies of our project require ext-intl. In order to run composer from the host (w/o passing --ignore-platform-reqs) we need to add it.